### PR TITLE
What is the percent in percent = val / (conf.nbWeeks) in multislider.js

### DIFF
--- a/app/ng-weekly-scheduler/js/directives/multislider.js
+++ b/app/ng-weekly-scheduler/js/directives/multislider.js
@@ -24,6 +24,11 @@ angular.module('weeklyScheduler')
         var defaultNewScheduleSize = parseInt(attrs.size) || 8;
 
         var valToPixel = function (val) {
+          /* Here i couldn't understand the meaning of this formula 
+            the val which is defaultNewScheduleSize (in "px") devided
+            by the number of weeks (a number).
+              What means this percent ?
+           */
           var percent = val / (conf.nbWeeks);
           return Math.floor(percent * element[0].clientWidth + 0.5);
         };

--- a/dist/js/ng-weekly-scheduler.js
+++ b/dist/js/ng-weekly-scheduler.js
@@ -359,6 +359,13 @@ angular.module('weeklyScheduler')
           // Install mouse scrolling event listener for H scrolling
           mouseScroll(el, 20);
 
+          /*
+            I have never heard about setting an event listener to an angular controller. 
+            So please ,can you tell me what does it means in this case and to which part of 
+            the angular API is it related to ?!
+
+            How this listener will interact with a change in the scheduler ?
+          */
           schedulerCtrl.on = {
             change: function (itemIndex, scheduleIndex, scheduleValue) {
               var onChangeFunction = $parse(attrs.onChange)(scope);


### PR DESCRIPTION
i wrote the question as a comment above the formula i can't understand in angular-weekly-scheduler\app\ng-weekly-scheduler\js\directives\multislider.js line 27 in the valToPixel function
which is in the multiSlider directive's link: function : 
```
       var valToPixel = function (val) {
          /* Here i couldn't understand the meaning of this formula 
            the val which is defaultNewScheduleSize (in "px") devided
            by the number of weeks (a number).
              What means this percent ?
           */
          var percent = val / (conf.nbWeeks);
          return Math.floor(percent * element[0].clientWidth + 0.5);
        };
```